### PR TITLE
Replace ref update and return func logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,11 @@
 //@ts-check
-var react = require('react')
-module.exports = function UseStateRef(defaultValue) {
-	var [state, setState] = react.useState(defaultValue)
-	var ref = react.useRef(defaultValue)
-	ref.current = state
-	return [
-		state,
-		function (newValue) {
-			ref.current = newValue
-			return setState(newValue)
-		},
-		ref
-	]
-}
+var React = require('react');
+
+module.exports = function useStateRef(defaultValue) {
+    var [state, setState] = React.useState(defaultValue);
+
+    var ref = React.useRef(defaultValue);
+    React.useEffect(() => (ref.current = state), [state]);  
+
+    return [ state, setState, ref ];
+};

--- a/index.js
+++ b/index.js
@@ -3,13 +3,13 @@ var React = require('react');
 
 module.exports = function useStateRef(defaultValue) {
   var [state, setState] = React.useState(defaultValue);
-  var ref = React.useRef(defaultValue);
+  var ref = React.useRef(state);
 
   var dispatch = React.useCallback(function(val) {
     ref.current = typeof val === "function" ?
     val(ref.current) : val;
 
-    setState(val);
+    setState(ref.current);
   }, []);
 
   return [state, dispatch, ref];

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var React = require('react');
 module.exports = function useStateRef(defaultValue) {
     var [state, setState] = React.useState(defaultValue);
 
-    var ref = React.useRef(defaultValue);
-    React.useEffect(() => (ref.current = state), [state]);  
+	var ref = React.useRef(defaultValue);
+	ref.current = state;
 
     return [ state, setState, ref ];
 };

--- a/index.js
+++ b/index.js
@@ -3,9 +3,14 @@ var React = require('react');
 
 module.exports = function useStateRef(defaultValue) {
   var [state, setState] = React.useState(defaultValue);
+  var ref = React.useRef(defaultValue);
 
-	var ref = React.useRef(defaultValue);
-	ref.current = state;
+  var dispatch = React.useCallback(function(val) {
+    ref.current = typeof val === "function" ?
+    val(ref.current) : val;
 
-  return [ state, setState, ref ];
+    setState(val);
+  }, []);
+
+  return [state, dispatch, ref];
 };


### PR DESCRIPTION
Hiya, I've just been debugging this for [someone on Stack Overflow](https://stackoverflow.com/questions/65782076/useeffect-on-infinite-loop-using-async-fetch-function).

As explained in the answer, there is an issue with returning a plain anonymous function as a state setter because it will be recreated on every render. This means it can't be used anywhere that requires it as a dependency. I've replaced it with the state setter itself, which has the added benefit of being able to use the callback version.

The logic for updating the ref can be moved directly into the body of the hook because it will always be the first thing to get updated after the state is updated. We can rely on the value being correct for effects further down the body of the user component.