### PR TITLE
Fixed typescript checking directive compatibility with IE9.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-//@ts-check
+// @ts-check
 var react = require('react')
 module.exports = function UseStateRef(defaultValue) {
 	var [state, setState] = react.useState(defaultValue)


### PR DESCRIPTION
For some reason IE9 does not like the `ts-check` directive, but when I add the space it works.
```
01/26/2021 16:53:41 DEBUG - Script error: errorLine (109098)
01/26/2021 16:53:41 DEBUG - Script error: errorCharacter (1)
01/26/2021 16:53:41 DEBUG - Script error: errorCode (0)
01/26/2021 16:53:41 DEBUG - Script error: errorMessage ('check' is undefined)
01/26/2021 16:53:41 DEBUG - Script error: errorUrl (http://127.0.0.1:3000/static/js/bundle.js)
```
It can be reproduced using:
```
<meta http-equiv="X-UA-Compatible" content="IE=9,chrome=1" />
```